### PR TITLE
make all message() calls conform to verbose

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: diffcyt
-Version: 1.3.24
+Version: 1.3.25
 Title: Differential discovery in high-dimensional cytometry via high-resolution clustering
 Description: Statistical methods for differential discovery analyses in high-dimensional cytometry data (including flow cytometry, mass cytometry or CyTOF, and oligonucleotide-tagged cytometry), based on a combination of high-resolution clustering and empirical Bayes moderated tests adapted from transcriptomics.
 Authors@R: person("Lukas M.", "Weber", email = "lukmweber@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3282-1730"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: diffcyt
-Version: 1.3.25
+Version: 1.3.24
 Title: Differential discovery in high-dimensional cytometry via high-resolution clustering
 Description: Statistical methods for differential discovery analyses in high-dimensional cytometry data (including flow cytometry, mass cytometry or CyTOF, and oligonucleotide-tagged cytometry), based on a combination of high-resolution clustering and empirical Bayes moderated tests adapted from transcriptomics.
 Authors@R: person("Lukas M.", "Weber", email = "lukmweber@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3282-1730"))

--- a/R/diffcyt_wrapper.R
+++ b/R/diffcyt_wrapper.R
@@ -357,14 +357,14 @@ diffcyt <- function(d_input, experiment_info = NULL, marker_info = NULL,
     
     if (is.null(clustering_to_use)) {
       stopifnot("cluster_id" %in% colnames(rowData(d_input)))
-      message("using cluster IDs stored in column named 'cluster_id' in 'rowData' of 'daFrame' object")
+      if(verbose) message("using cluster IDs stored in column named 'cluster_id' in 'rowData' of 'daFrame' object")
       # clustering identifier to store in metadata
       clustering_name <- colnames(metadata(d_input)$cluster_codes)[1]
       
     } else if (!is.null(clustering_to_use)) {
       stopifnot(as.character(clustering_to_use) %in% colnames(metadata(d_input)$cluster_codes))
       stopifnot("cluster_id" %in% colnames(rowData(d_input)))
-      message("using cluster IDs from clustering stored in column '", clustering_to_use, "' of 'cluster_codes' ", 
+      if(verbose) message("using cluster IDs from clustering stored in column '", clustering_to_use, "' of 'cluster_codes' ", 
               "data frame in 'metadata' of 'daFrame' object")
       code_id <- rowData(d_input)$cluster_id
       cluster_id <- metadata(d_input)$cluster_codes[, clustering_to_use][code_id]

--- a/R/diffcyt_wrapper.R
+++ b/R/diffcyt_wrapper.R
@@ -357,15 +357,15 @@ diffcyt <- function(d_input, experiment_info = NULL, marker_info = NULL,
     
     if (is.null(clustering_to_use)) {
       stopifnot("cluster_id" %in% colnames(rowData(d_input)))
-      if(verbose) message("using cluster IDs stored in column named 'cluster_id' in 'rowData' of 'daFrame' object")
+      if (verbose) message("using cluster IDs stored in column named 'cluster_id' in 'rowData' of 'daFrame' object")
       # clustering identifier to store in metadata
       clustering_name <- colnames(metadata(d_input)$cluster_codes)[1]
       
     } else if (!is.null(clustering_to_use)) {
       stopifnot(as.character(clustering_to_use) %in% colnames(metadata(d_input)$cluster_codes))
       stopifnot("cluster_id" %in% colnames(rowData(d_input)))
-      if(verbose) message("using cluster IDs from clustering stored in column '", clustering_to_use, "' of 'cluster_codes' ", 
-              "data frame in 'metadata' of 'daFrame' object")
+      if (verbose) message("using cluster IDs from clustering stored in column '", clustering_to_use, "' of 'cluster_codes' ", 
+                           "data frame in 'metadata' of 'daFrame' object")
       code_id <- rowData(d_input)$cluster_id
       cluster_id <- metadata(d_input)$cluster_codes[, clustering_to_use][code_id]
       # store cluster labels in column 'cluster_id' in 'rowData'; and add column 'code_id'


### PR DESCRIPTION
Maybe this was intentional, but I always find it weird to send out message()s when verbose=FALSE. This PR makes it consistent.

If it is intentional, maybe you can changes the docs ("Whether to print status messages during each step of the pipeline.") to say what it actually does.